### PR TITLE
Fix on namespace erorr when building flutter 3.29

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest package="com.shounakmulay.telephony"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 </manifest>


### PR DESCRIPTION
removed namespace from AndroidManifest.xml to support higher versions of gradle  8 and above

Solves issue #8 

See [this stack overflow post](https://stackoverflow.com/questions/76108428/how-do-i-fix-namespace-not-specified-error-in-android-studio) for more information